### PR TITLE
Fix global stylesheet import for Astro 4

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -1,4 +1,6 @@
 ---
+import globalStylesHref from '../styles/global.css?url';
+
 const { title = 'Perth Crypto News & Discussion', description = 'Stay ahead with the latest crypto headlines, market snapshots, and community conversations from Perth.' } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -12,7 +14,7 @@ const { title = 'Perth Crypto News & Discussion', description = 'Stay ahead with
     <link rel="stylesheet" href="/reset.css" />
     <link rel="stylesheet" href="/noise.css" />
     <link rel="stylesheet" href="/stars.css" />
-    <link rel="stylesheet" href={Astro.resolve('../styles/global.css')} />
+    <link rel="stylesheet" href={globalStylesHref} />
   </head>
   <body>
     <header class="site-header">


### PR DESCRIPTION
## Summary
- import the global stylesheet with the `?url` suffix and reuse it in the layout head
- remove the deprecated `Astro.resolve` usage to make the layout compatible with Astro 4

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eac31cb80083268ae154871f7fd1ec