### PR TITLE
Disable Netlify Next.js plugin for Astro build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
## Summary
- set the `NETLIFY_NEXT_PLUGIN_SKIP` environment variable in `netlify.toml` so Netlify skips the Next.js plugin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eac45d85308326ae0a96106ff6f694